### PR TITLE
Use libc to be more resilient and compatible.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ mod attr {
         }
 
         pub fn set_terminal_attr(fd: RawFd, termios: &Termios) -> io::Result<()> {
-            convert_to_result(unsafe { libc::tcsetattr(fd, 0, termios) }).and(Ok(()))
+            convert_to_result(unsafe { libc::tcsetattr(fd, libc::TCSANOW, termios) }).and(Ok(()))
         }
 
         pub fn raw_terminal_attr(termios: &mut Termios) {


### PR DESCRIPTION
The first commit just switches to calling the functions defined in `libc` instead of trying to link against them directly. This fixes the first issue on some platforms like illumos/solaris where `cfmakeraw` isn't defined but `libc` includes a [shim](https://github.com/rust-lang/libc/blob/dc343939e5e0c5a36e354e8eb808b4c2e0a80700/src/unix/solarish/compat.rs#L9-L32).

The second commit uses the constant `TCSANOW` instead of hardcoding 0.

With these two fixes, `cargo test` passes for me without a linker error (first issue) or failing with invalid argument (second issue).