### PR TITLE
Ignore error when restoring termio settings on drop.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@ pub struct TtyModeGuard {
 
 impl Drop for TtyModeGuard {
     fn drop(&mut self) {
-        set_terminal_attr(self.fd, &self.ios).unwrap();
+        set_terminal_attr(self.fd, &self.ios).ok();
     }
 }
 


### PR DESCRIPTION
Otherwise we may get a panic like this on drop when the underlying tty has gone bad:
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 5, kind: Uncategorized, message: "Input/output error" }', [...]/src/lib.rs:168:47